### PR TITLE
Generate XML for MS CryptoServiceProvider

### DIFF
--- a/source/LbBigInt.pas
+++ b/source/LbBigInt.pas
@@ -72,6 +72,7 @@ type
     function GetBase64Str : string;
     procedure SetBase64Str(const Value: string);
     procedure SetHexStr(const Value: string);
+    function GetASN1Text: String;
   protected {private}
       FI : LbInteger;
       procedure setSign(value : Boolean);
@@ -107,8 +108,8 @@ type
       function IsEven : Boolean;
       function IsComposite(Iterations : Cardinal) : Boolean;
       function Abs(I2 : TLbBigInt) : ShortInt;
-      procedure ReverseBits;
-      procedure ReverseBytes;
+      procedure ReverseBits(WithTrim : Boolean = True);
+      procedure ReverseBytes(WithTrim : Boolean = True);
       function GetBit(bit : Integer) : Boolean;
       procedure Shr_(_shr : Integer);
       procedure Shl_(_shl : Integer);
@@ -147,6 +148,7 @@ type
       property IntStr : string read GetHexStr write SetHexStr;
       property Size : integer read GetSize;
       property Base64Str : string read GetBase64Str write SetBase64Str;
+      property ASN1Text : String read GetASN1Text;
 
 end;
 
@@ -532,7 +534,7 @@ begin
   end;
 end;
 { ------------------------------------------------------------------- }
-procedure LbBiVerify(var N1 : LbInteger);
+procedure LbBiVerify(var N1 : LbInteger; WithTrim : Boolean = True);
 begin
   { check to see that pointer points at data }
   if (not(assigned(N1.IntBuf.pBuf))) then
@@ -542,7 +544,10 @@ begin
   if (N1.dwUsed = 0) then
       raise Exception.Create(sBINoNumber);
 
-  LbBiTrimSigZeros(N1);  
+  if WithTrim then
+  begin
+    LbBiTrimSigZeros(N1);
+  end;
 end;
 { ------------------------------------------------------------------- }
 procedure LbBiFindLargestUsed(N1 : LbInteger; N2 : LbInteger; out count : integer); {!!03}
@@ -2539,15 +2544,15 @@ begin
   LbBiCopyBigInt2Buf(FI, cPREPEND_ARRAY, @Buf, len);
 end;
 { ------------------------------------------------------------------- }
-procedure TLbBigInt.ReverseBits;
+procedure TLbBigInt.ReverseBits(WithTrim : Boolean);
 begin
-  LbBiVerify(FI);
+  LbBiVerify(FI, WithTrim);
   LbBiReverseBitsInPlace(FI);
 end;
 { ------------------------------------------------------------------- }
-procedure TLbBigInt.ReverseBytes;
+procedure TLbBigInt.ReverseBytes(WithTrim : Boolean);
 begin
-  LbBiVerify(FI);
+  LbBiVerify(FI, WithTrim);
   LbBiReverseBytesInPlace(FI);
 end;
 { ------------------------------------------------------------------- }
@@ -2621,6 +2626,26 @@ end;
 procedure TLbBigInt.GCD(I2: TLbBigInt);
 begin
   LbGreatestCommonDivisor(self, I2);
+end;
+{ ------------------------------------------------------------------- }
+function TLbBigInt.GetASN1Text: String;
+var
+  ReversedBigInt : TLbBigInt;
+begin
+  ReversedBigInt := TlbBigInt.Create(Size);
+  try
+    ReversedBigInt.Copy(self);
+    //insert a leading zero if the first bit is set
+    if ReversedBigInt.GetBit(ReversedBigInt.Size * 8 - 1) then
+    begin
+      ReversedBigInt.AppendByte(0); //do this before reversal
+    end;
+
+    ReversedBigInt.ReverseBytes(False); //don't trim the null byte
+    Result := ASN1HexSize(ReversedBigInt.Size) + ReversedBigInt.IntStr;
+  finally
+    ReversedBigInt.Free;
+  end;
 end;
 { ------------------------------------------------------------------- }
 function TLbBigInt.GetBase64Str : string;

--- a/source/LbDSA.pas
+++ b/source/LbDSA.pas
@@ -336,13 +336,8 @@ end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSAParameters.SetQAsString(const Value : string);
   { set q to value represented by "big to little" hex string }
-var
-  Buf : TLbDSABlock;
 begin
-  FillChar(Buf, SizeOf(Buf), #0);
-  HexToBuffer(Value, Buf, SizeOf(Buf));
-  FQ.CopyBuffer(Buf, SizeOf(Buf));
-  FQ.Trim;
+  FQ.IntStr := Value;
 end;
 { -------------------------------------------------------------------------- }
 function TLbDSAParameters.GetGAsString : string;
@@ -353,13 +348,8 @@ end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSAParameters.SetGAsString(const Value : string);
   { set g to value represented by "big to little" hex string }
-var
-  Buf : array[Byte] of Byte;
 begin
-  FillChar(Buf, SizeOf(Buf), #0);
-  HexToBuffer(Value, Buf, cLbAsymKeyBytes[FKeySize]);
-  FG.CopyBuffer(Buf, cLbAsymKeyBytes[FKeySize]);
-  FG.Trim;
+  FG.IntStr := Value;
 end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSAParameters.CopyDSAParameters(aKey : TLbDSAParameters);
@@ -637,13 +627,8 @@ end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSAPrivateKey.SetXAsString(const Value : string);
   { set x to value represented by "big to little" hex string }
-var
-  Buf : TLbDSABlock;
 begin
-  FillChar(Buf, SizeOf(Buf), #0);
-  HexToBuffer(Value, Buf, SizeOf(Buf));
-  FX.CopyBuffer(Buf, SizeOf(Buf));
-  FX.Trim;
+  FX.IntStr := Value;
 end;
 { -------------------------------------------------------------------------- }
 {!!.06}
@@ -735,13 +720,8 @@ end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSAPublicKey.SetYAsString(const Value : string);
   { set y to value represented by "big to little" hex string }
-var
-  Buf : array[Byte] of Byte;
 begin
-  FillChar(Buf, SizeOf(Buf), #0);
-  HexToBuffer(Value, Buf, cLbAsymKeyBytes[FKeySize]);
-  FY.CopyBuffer(Buf, cLbAsymKeyBytes[FKeySize]);
-  FY.Trim;
+  FY.IntStr := Value;
 end;
 { -------------------------------------------------------------------------- }
 {!!.06}
@@ -1090,10 +1070,14 @@ end;
 procedure TLbDSA.SignFile(const AFileName : string);
   { generate DSA signature of file data }
 var
-  Digest : TSHA1Digest;
+  Stream : TStream;
 begin
-  FileHashSHA1(Digest, AFileName);
-  SignHash(Digest);
+  Stream := TFileStream.Create(AFileName, fmOpenRead);
+  try
+    SignStream(Stream);
+  finally
+    Stream.Free;
+  end;
 end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSA.SignStream(AStream : TStream);
@@ -1107,11 +1091,8 @@ end;
 { -------------------------------------------------------------------------- }
 procedure TLbDSA.SignString(const AStr : RawByteString);
   { generate DSA signature of string data }
-var
-  Digest : TSHA1Digest;
 begin
-  StringHashSHA1(Digest, AStr);
-  SignHash(Digest);
+  SignBuffer(AStr[1], Length(AStr));
 end;
 { -------------------------------------------------------------------------- }
 function TLbDSA.VerifyBuffer(const Buf; BufLen : Cardinal) : Boolean;
@@ -1126,10 +1107,14 @@ end;
 function TLbDSA.VerifyFile(const AFileName : string) : Boolean;
   { verify DSA signature agrees with file data }
 var
-  Digest : TSHA1Digest;
+  Stream : TStream;
 begin
-  FileHashSHA1(Digest, AFileName);
-  Result := VerifyHash(Digest);
+  Stream := TFileStream.Create(AFileName, fmOpenRead);
+  try
+    Result := VerifyStream(Stream);
+  finally
+    Stream.Free;
+  end;
 end;
 { -------------------------------------------------------------------------- }
 function TLbDSA.VerifyStream(AStream : TStream) : Boolean;
@@ -1143,11 +1128,8 @@ end;
 { -------------------------------------------------------------------------- }
 function TLbDSA.VerifyString(const AStr : RawByteString) : Boolean;
   { verify DSA signature agrees with string data }
-var
-  Digest : TSHA1Digest;
 begin
-  StringHashSHA1(Digest, AStr);
-  Result := VerifyHash(Digest);
+  Result := VerifyBuffer(AStr[1], Length(AStr));
 end;
 
 end.

--- a/source/LbKeyEd2.pas
+++ b/source/LbKeyEd2.pas
@@ -142,7 +142,7 @@ begin
   Pri := TLbRSAKey.Create(TLbAsymKeySize(cbxKeySize.ItemIndex));
   try
     GenerateRSAKeysEx(Pri, Pub, TLbAsymKeySize(cbxKeySize.ItemIndex),
-      StrToIntDef(edtIterations.Text, 20), RSACallback);
+      StrToIntDef(edtIterations.Text, 20), nil, RSACallback);
     edtModulus.Text := Pri.ModulusAsString;
     edtPublicExponent.Text := Pub.ExponentAsString;
     edtPrivateExponent.Text := Pri.ExponentAsString;

--- a/source/LbProc.pas
+++ b/source/LbProc.pas
@@ -108,9 +108,7 @@ procedure RDLEncryptStreamCBC(InStream, OutStream : TStream;
             const Key; KeySize : Longint; Encrypt : Boolean);
 
 { high level hashing routines }
-procedure FileHashMD5(var Digest : TMD5Digest; const AFileName : string);
 procedure StreamHashMD5(var Digest : TMD5Digest; AStream : TStream);
-procedure FileHashSHA1(var Digest : TSHA1Digest; const AFileName : string);
 procedure StreamHashSHA1(var Digest : TSHA1Digest; AStream : TStream);
 
 
@@ -1334,18 +1332,6 @@ end;
 
 
 { == MD5 =================================================================== }
-procedure FileHashMD5(var Digest : TMD5Digest; const AFileName : string);
-var
-  FS : TFileStream;
-begin
-  FS := TFileStream.Create(AFileName, fmOpenRead);
-  try
-    StreamHashMD5(Digest, FS);
-  finally
-    FS.Free;
-  end;
-end;
-{ -------------------------------------------------------------------------- }
 procedure StreamHashMD5(var Digest : TMD5Digest; AStream : TStream);
 var
   BufSize : Cardinal;
@@ -1363,18 +1349,6 @@ end;
 
 
 { == SHA1 ================================================================== }
-procedure FileHashSHA1(var Digest : TSHA1Digest; const AFileName : string);
-var
-  FS : TFileStream;
-begin
-  FS := TFileStream.Create(AFileName, fmOpenRead);
-  try
-    StreamHashSHA1(Digest, FS);
-  finally
-    FS.Free;
-  end;
-end;
-{ -------------------------------------------------------------------------- }
 procedure StreamHashSHA1(var Digest : TSHA1Digest; AStream : TStream);
 var
   BufSize : Cardinal;

--- a/source/LbUtils.pas
+++ b/source/LbUtils.pas
@@ -38,6 +38,8 @@ interface
 uses
   SysUtils;
 
+function HexToBase64(const HexValue : String) : String;
+function Base64ToHex(const Base64Value : String) : String;
 function BufferToBase64(const Buf; BufSize : Cardinal) : String;
 function Base64ToBuffer(const Base64Text : string; var Buf; out BufferSize : Cardinal) : Boolean;
 function BufferToHex(const Buf; BufSize : Cardinal) : string;
@@ -45,6 +47,8 @@ function HexToBuffer(const Hex : string; var Buf; BufSize : Cardinal) : Boolean;
 function Min(A, B : LongInt) : LongInt;
 function Max(A, B : LongInt) : LongInt;
 function CompareBuffers(const Buf1, Buf2; BufSize : Cardinal) : Boolean;
+function ASN1HexSize(AByteCount : Integer) : String;
+
 
 {$IFDEF Debugging}
 procedure DebugStr(const AStr : string);
@@ -124,6 +128,40 @@ begin
   DebugLogFileName := AFileName;
 end;
 {$ENDIF}
+
+{ -------------------------------------------------------------------------- }
+function HexToBase64(const HexValue : String) : String;
+var
+  Stream : TMemoryStream;
+begin
+  Stream := TMemoryStream.Create;
+  Stream.Size := Length(HexValue) div 2;
+  try
+    HexToBuffer(HexValue, Stream.Memory^, Stream.Size);
+    Stream.Position := 0;
+    Result := BufferToBase64(Stream.Memory^, Stream.Size);
+  finally
+    Stream.Free;
+  end;
+end;
+
+{ -------------------------------------------------------------------------- }
+function Base64ToHex(const Base64Value : String) : String;
+var
+  Stream : TMemoryStream;
+  BufferSize : Cardinal;
+begin
+  Stream := TMemoryStream.Create;
+  Stream.Size := Length(Base64Value) * 3 div 4;
+  try
+    Base64ToBuffer(Base64Value, Stream.Memory^, BufferSize);
+    assert(Stream.Size = BufferSize);
+    Stream.Position := 0;
+    Result := BufferToHex(Stream.Memory^, Stream.Size);
+  finally
+    Stream.Free;
+  end;
+end;
 
 { -------------------------------------------------------------------------- }
 function Base64ToBuffer(const Base64Text : string; var Buf; out BufferSize : Cardinal) : Boolean;
@@ -240,6 +278,29 @@ begin
       Break;
   end;
 end;
+{ -------------------------------------------------------------------------- }
+function ASN1HexSize(AByteCount : Integer) : String;
+const
+  EXTENDED_SIZE_TAG = '8%d';
+var
+  BytePower : Byte;
+begin
+  BytePower := 0;
+  while (AByteCount <> 0) do
+  begin
+    AByteCount := AByteCount shr 8;
+    inc(BytePower);
+  end;
+
+  Result := IntToHex(AByteCount, 2 * BytePower);
+  //if the size is greater than 127 bytes, prefix the size with 8x,
+  //where x is the number of bytes needed to represent the byte count as a number
+  if (AByteCount > 127) then
+  begin
+    Result := Format(EXTENDED_SIZE_TAG,[BytePower]) + Result;
+  end;
+end;
+
 
 end.
 


### PR DESCRIPTION
This patch enables RSA keys to output XML required by the CryptoServiceProvider class in C# and allows a hash algorithm identifier to be embedded in a signed document, according to the PKCS#1 specification, so that the signature is compatible with MS cryptography.

The exponent of a public RSA key can now be specified during key generation, so that a value of $010001 can be prescribed to meet optimum security requirements.

OpenSSL text for RSA ciphers has been added.